### PR TITLE
Fix `TypeError: get_url() got an unexpected keyword argument host`

### DIFF
--- a/memberpress_client/client.py
+++ b/memberpress_client/client.py
@@ -46,8 +46,8 @@ class MemberpressAPIClient(Memberpress):
         }
 
     @request_manager
-    def post(self, path, data=None, host=None, operation="") -> json:
-        url = self.get_url(path, host=host)
+    def post(self, path, data=None, operation="") -> json:
+        url = self.get_url(path)
         log_pretrip(caller=inspect.currentframe().f_code.co_name, url=url, data=data, operation=operation)
         response = requests.post(url, data=data, headers=self.headers)
         log_postrip(caller=inspect.currentframe().f_code.co_name, path=url, response=response, operation=operation)
@@ -55,8 +55,8 @@ class MemberpressAPIClient(Memberpress):
         return response.json()
 
     @request_manager
-    def patch(self, path, data=None, host=None, headers=None, json=True, operation=""):
-        url = self.get_url(path, host=host)
+    def patch(self, path, data=None, headers=None, json=True, operation=""):
+        url = self.get_url(path)
         if not headers:
             headers = self.headers
 


### PR DESCRIPTION
There is a type error in client.py because `def get_url` does not accept a `host` arg/kwarg yet `def post` and `def patch` pass in a `host` kwarg to `self.get_url`. In this PR the `host` kwarg is removed both from the calls to `self.get_url` and the kwargs of `def post` and `def patch` since it is not used anywhere.